### PR TITLE
add test for leak of closed streams

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,7 @@
 {erl_opts, [debug_info]}.
 
-{deps, [{chatterbox, {pkg, ts_chatterbox}},
+{deps, [%% {chatterbox, {pkg, ts_chatterbox}},
+        {chatterbox, {git, "https://github.com/tsloughter/chatterbox", {branch, "garbage-stream"}}},
         ctx,
         acceptor_pool,
         gproc]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,19 +1,20 @@
 {"1.2.0",
 [{<<"acceptor_pool">>,{pkg,<<"acceptor_pool">>,<<"1.0.0">>},0},
- {<<"chatterbox">>,{pkg,<<"ts_chatterbox">>,<<"0.9.1">>},0},
+ {<<"chatterbox">>,
+  {git,"https://github.com/tsloughter/chatterbox",
+       {ref,"b56daf39c645e8ddd071bf71760b5c5046363c14"}},
+  0},
  {<<"ctx">>,{pkg,<<"ctx">>,<<"0.6.0">>},0},
  {<<"gproc">>,{pkg,<<"gproc">>,<<"0.8.0">>},0},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},1}]}.
 [
 {pkg_hash,[
  {<<"acceptor_pool">>, <<"43C20D2ACAE35F0C2BCD64F9D2BDE267E459F0F3FD23DAB26485BF518C281B21">>},
- {<<"chatterbox">>, <<"843557EE729B04B3C1BDAC33FB162DAEFDBF4F7AE0AF0BDC055FB16E91E057E3">>},
  {<<"ctx">>, <<"8FF88B70E6400C4DF90142E7F130625B82086077A45364A78D208ED3ED53C7FE">>},
  {<<"gproc">>, <<"CEA02C578589C61E5341FCE149EA36CCEF236CC2ECAC8691FBA408E7EA77EC2F">>},
  {<<"hpack">>, <<"17670F83FF984AE6CD74B1C456EDDE906D27FF013740EE4D9EFAA4F1BF999633">>}]},
 {pkg_hash_ext,[
  {<<"acceptor_pool">>, <<"0CBCD83FDC8B9AD2EEE2067EF8B91A14858A5883CB7CD800E6FCD5803E158788">>},
- {<<"chatterbox">>, <<"D5427C3701CCE85A7B7F9977A4A44B98E527494F6CB598717585A332EF4107B4">>},
  {<<"ctx">>, <<"A14ED2D1B67723DBEBBE423B28D7615EB0BDCBA6FF28F2D1F1B0A7E1D4AA5FC2">>},
  {<<"gproc">>, <<"580ADAFA56463B75263EF5A5DF4C86AF321F68694E7786CB057FD805D1E2A7DE">>},
  {<<"hpack">>, <<"06F580167C4B8B8A6429040DF36CC93BBA6D571FAEAEC1B28816523379CBB23A">>}]}

--- a/src/grpcbox_client.erl
+++ b/src/grpcbox_client.erl
@@ -202,8 +202,8 @@ recv(Type, #{stream_id := Id,
     end.
 
 recv_end(#{stream_id := StreamId,
-           stream_pid := Pid,
-           monitor_ref := Ref}, Timeout) ->
+            stream_pid := Pid,
+            monitor_ref := Ref}, Timeout) ->
     receive
         {eos, StreamId} ->
             erlang:demonitor(Ref, [flush]),

--- a/src/grpcbox_client.erl
+++ b/src/grpcbox_client.erl
@@ -71,7 +71,7 @@ unary(Ctx, Path, Input, Def, Options) ->
 unary_handler(Ctx, Channel, Path, Input, Def, Options) ->
     try
         case grpcbox_client_stream:send_request(Ctx, Channel, Path, Input, Def, Options) of
-            {ok, _, Stream, Pid} ->
+            {ok, _Conn, Stream, Pid} ->
                 Ref = erlang:monitor(process, Pid),
                 S = #{channel => Channel,
                       stream_id => Stream,

--- a/src/grpcbox_client_stream.erl
+++ b/src/grpcbox_client_stream.erl
@@ -133,7 +133,7 @@ metadata_headers(Ctx) ->
 
 %% callbacks
 
-init(_, StreamId, [_, State=#{path := Path}]) ->
+init(_ConnectionPid, StreamId, [_, State=#{path := Path}]) ->
     _ = process_flag(trap_exit, true),
     Ctx1 = ctx:with_value(ctx:new(), grpc_client_method, Path),
     State1 = stats_handler(Ctx1, rpc_begin, {}, State),

--- a/src/grpcbox_services_simple_sup.erl
+++ b/src/grpcbox_services_simple_sup.erl
@@ -28,7 +28,12 @@ start_child(Opts) ->
     supervisor:start_child(?SERVER, [ServerOpts, GrpcOpts, ListenOpts, PoolOpts, TransportOpts]).
 
 terminate_child(ListenOpts) ->
-    supervisor:terminate_child(?SERVER, whereis(grpcbox_services_sup:services_sup_name(ListenOpts))).
+    case whereis(grpcbox_services_sup:services_sup_name(ListenOpts)) of
+        undefined ->
+            ok;
+        Pid ->
+            supervisor:terminate_child(?SERVER, Pid)
+    end.
 
 init(_Args) ->
     SupFlags = #{strategy => simple_one_for_one,

--- a/src/grpcbox_subchannel.erl
+++ b/src/grpcbox_subchannel.erl
@@ -94,7 +94,8 @@ terminate(_Reason, _State, #data{conn=Pid,
 connect(Data=#data{conn=undefined,
                    endpoint={Transport, Host, Port, SSLOptions}}, From, Actions) ->
     case h2_client:start_link(Transport, Host, Port, options(Transport, SSLOptions),
-                             #{stream_callback_mod => grpcbox_client_stream}) of
+                             #{garbage_on_end => true,
+                               stream_callback_mod => grpcbox_client_stream}) of
         {ok, Pid} ->
             {next_state, ready, Data#data{conn=Pid}, Actions};
         {error, _}=Error ->


### PR DESCRIPTION
Fix not included yet and this won't be merged until I have the fix included in this PR.

Technically for unary requests you could add one line 82 in `grpcbox_client`:

```
_ = h2_client:get_response(Conn, Stream),
```

But this is not a proper fix and only "fixes" unary calls.