### PR TITLE
The latency metrics always infinity

### DIFF
--- a/src/grpcbox_oc_stats.erl
+++ b/src/grpcbox_oc_stats.erl
@@ -40,10 +40,10 @@ register_measures_(client) ->
       bytes},
      {'grpc.io/client/roundtrip_latency',
       "Time between first byte of request sent to last byte of response received, or terminal error.",
-      millisecond},
+      microsecond},
      {'grpc.io/client/server_latency',
       "Propagated from the server and should have the same value as grpc.io/server/latency.",
-      millisecond},
+      microsecond},
      {'grpc.io/client/started_rpcs',
       "The total number of client RPCs ever opened, including those that have not completed.",
       none}];
@@ -62,7 +62,7 @@ register_measures_(server) ->
       bytes},
      {'grpc.io/server/server_latency',
       "Time between first byte of request received to last byte of response sent, or terminal error.",
-      millisecond},
+      microsecond},
      {'grpc.io/server/started_rpcs',
       "The total number of server RPCs ever opened, including those that have not completed.",
       none}].
@@ -88,6 +88,7 @@ default_views(client) ->
        description => "Distribution of time taken by request.",
        tags => [grpc_client_method],
        measure => 'grpc.io/client/roundtrip_latency',
+       unit => microsecond,
        aggregation => default_latency_distribution()},
      #{name => "grpc.io/client/completed_rpcs",
        description => "Total count of completed rpcs",
@@ -114,6 +115,7 @@ default_views(server) ->
        description => "Distribution of time taken by request.",
        tags => [grpc_server_method],
        measure => 'grpc.io/server/server_latency',
+       unit => microsecond,
        aggregation => default_latency_distribution()},
      #{name => "grpc.io/server/completed_rpcs",
        description => "Total count of completed rpcs",
@@ -135,6 +137,7 @@ extra_views(client) ->
        description => "Distribution of messages received per RPC",
        tags => [grpc_client_method],
        measure => 'grpc.io/client/received_messages_per_rpc',
+       unit => microsecond,
        aggregation => default_latency_distribution()},
      #{name => "grpc.io/client/sent_messages_per_rpc",
        description => "Distribution of messages sent per RPC",
@@ -145,12 +148,14 @@ extra_views(client) ->
        description => "Distribution of latency value propagated from the server.",
        tags => [grpc_client_method],
        measure => 'grpc.io/client/server_latency',
+       unit => microsecond,
        aggregation => default_latency_distribution()}];
 extra_views(server) ->
     [#{name => "grpc.io/server/received_messages_per_rpc",
        description => "Distribution of messages received per RPC",
        tags => [grpc_server_method],
        measure => 'grpc.io/server/received_messages_per_rpc',
+       unit => microsecond,
        aggregation => default_latency_distribution()},
      #{name => "grpc.io/server/sent_messages_per_rpc",
        description => "Distribution of messages sent per RPC",
@@ -165,7 +170,9 @@ default_size_distribution() ->
                                                    4294967296]}]}.
 
 default_latency_distribution() ->
-    {oc_stat_aggregation_distribution, [{buckets, [0, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30,
-                                                   40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400,
-                                                   500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000,
-                                                   100000]}]}.
+    {oc_stat_aggregation_distribution,
+     [{buckets, [0, 1000, 2000, 3000, 4000, 5000, 6000, 8000,
+                 10000, 13000, 16000, 20000, 25000, 30000, 40000, 50000, 65000, 80000,
+                 100000, 130000, 160000, 200000, 250000, 300000, 400000, 500000, 650000, 800000,
+                 1000000, 2000000, 5000000, 10000000, 20000000, 50000000,
+                 100000000]}]}.

--- a/src/grpcbox_oc_stats.erl
+++ b/src/grpcbox_oc_stats.erl
@@ -40,10 +40,10 @@ register_measures_(client) ->
       bytes},
      {'grpc.io/client/roundtrip_latency',
       "Time between first byte of request sent to last byte of response received, or terminal error.",
-      milli_seconds},
+      millisecond},
      {'grpc.io/client/server_latency',
       "Propagated from the server and should have the same value as grpc.io/server/latency.",
-      milli_seconds},
+      millisecond},
      {'grpc.io/client/started_rpcs',
       "The total number of client RPCs ever opened, including those that have not completed.",
       none}];
@@ -62,7 +62,7 @@ register_measures_(server) ->
       bytes},
      {'grpc.io/server/server_latency',
       "Time between first byte of request received to last byte of response sent, or terminal error.",
-      milli_seconds},
+      millisecond},
      {'grpc.io/server/started_rpcs',
       "The total number of server RPCs ever opened, including those that have not completed.",
       none}].

--- a/src/grpcbox_oc_stats_handler.erl
+++ b/src/grpcbox_oc_stats_handler.erl
@@ -23,12 +23,12 @@ handle(Ctx, server, rpc_begin, _, _) ->
     Method = ctx:get(Ctx, grpc_server_method),
     Tags = #{grpc_server_method => Method},
     oc_stat:record(Tags, [{'grpc.io/server/started_rpcs', 1}]),
-    {oc_tags:new(Ctx, Tags), #stats{start_time=erlang:monotonic_time()}};
+    {oc_tags:new(Ctx, Tags), #stats{start_time=erlang:monotonic_time(microsecond)}};
 handle(Ctx, client, rpc_begin, _, _) ->
     Method = ctx:get(Ctx, grpc_client_method),
     Tags = #{grpc_client_method => Method},
     oc_stat:record(Tags, 'grpc.io/client/started_rpcs', 1),
-    {oc_tags:new(Ctx, Tags), #stats{start_time=erlang:monotonic_time()}};
+    {oc_tags:new(Ctx, Tags), #stats{start_time=erlang:monotonic_time(microsecond)}};
 handle(Ctx, _, out_payload, #{uncompressed_size := USize,
                               compressed_size := _CSize}, Stats=#stats{sent_count=SentCount,
                                                                        sent_bytes=SentBytes}) ->
@@ -46,7 +46,7 @@ handle(Ctx, server, rpc_end, _, Stats=#stats{start_time=StartTime,
                                              sent_bytes=SentBytes,
                                              recv_count=RecvCount,
                                              recv_bytes=RecvBytes}) ->
-    EndTime = erlang:monotonic_time(),
+    EndTime = erlang:monotonic_time(microsecond),
     Status = ctx:get(Ctx, grpc_server_status),
     Ctx1 = oc_tags:new(Ctx, #{grpc_server_status => Status}),
     oc_stat:record(Ctx1, [{'grpc.io/server/server_latency', EndTime - StartTime},
@@ -61,7 +61,7 @@ handle(Ctx, client, rpc_end, _, Stats=#stats{start_time=StartTime,
                                              sent_bytes=SentBytes,
                                              recv_count=RecvCount,
                                              recv_bytes=RecvBytes}) ->
-    EndTime = erlang:monotonic_time(),
+    EndTime = erlang:monotonic_time(microsecond),
     Status = ctx:get(Ctx, grpc_client_status),
     Ctx1 = oc_tags:new(Ctx, #{grpc_client_status => Status}),
     oc_stat:record(Ctx1, [{'grpc.io/client/roundtrip_latency', EndTime - StartTime},

--- a/test/grpcbox_SUITE.erl
+++ b/test/grpcbox_SUITE.erl
@@ -35,7 +35,7 @@ all() ->
      client_stream_garbage_collect_streams,
      compression,
      stats_handler,
-     stats,
+     server_latency_stats,
      health_service,
      reflection_service
      %% TODO: rst stream error handling
@@ -236,7 +236,7 @@ init_per_testcase(stats_handler, Config) ->
                                           stats_handler => test_stats_handler}}]),
     application:ensure_all_started(grpcbox),
     Config;
-init_per_testcase(stats, Config) ->
+init_per_testcase(server_latency_stats, Config) ->
     application:set_env(grpcbox, client, #{channels => [{default_channel,
                                                          [{http, "localhost", 8080, []}], #{}}]}),
     application:set_env(grpcbox, servers,
@@ -293,7 +293,7 @@ end_per_testcase(trace_interceptor, _Config) ->
                                                                    port => 8080})),
     application:stop(grpcbox),
     ok;
-end_per_testcase(stats, _Config) ->
+end_per_testcase(server_latency_stats, _Config) ->
     application:stop(opencensus),
     ?assertMatch(ok, grpcbox_services_simple_sup:terminate_child(#{ip => {0, 0, 0, 0},
                                                                    port => 8080})),
@@ -495,30 +495,40 @@ stats_handler(_Config) ->
 
     ?assert(maps:get(rpc_end, Stats) > maps:get(rpc_begin, Stats)).
 
--define(server_latency_buckets(Buckets),
-        {view, "grpc.io/server/server_latency", _Measure, _, _B, _Help, _M, _Methods, oc_stat_aggregation_distribution, Buckets}).
+-define(server_latency_view(View),
+        {ok, {view, "grpc.io/server/server_latency", _Measure, _, _B, _Help, _M, _Methods, oc_stat_aggregation_distribution, _Buckets} = View}).
 
-stats(_Config) ->
+server_latency_stats(_Config) ->
     Registered = grpcbox_oc_stats_handler:init(),
     Subscribed = grpcbox_oc_stats:subscribe_views(),
-    OkSubscribed = [S || {ok, S} <- Subscribed],
 
     ?assertEqual(ok, Registered),
-    ?assertEqual(length(Subscribed), length(OkSubscribed)),
+    ?assertEqual([], lists:filter(fun ({Ok, _}) -> ok =/= Ok end, Subscribed)),
 
-    [{SrvLatencyBuckets, SrvLatencyView}] = [{Buckets, View} || ?server_latency_buckets(Buckets) = View <- OkSubscribed],
+    [SrvLatencyView] = [View || ?server_latency_view(View) <- Subscribed],
 
-    ?assertEqual(36, length(SrvLatencyBuckets)),
+    Args = [ctx:new(), #{latitude => 409146138, longitude => -746188906}, #{encoding => gzip}],
+    {MeasuredTime, {ok, Feature, _}} =
+        timer:tc(routeguide_route_guide_client, get_feature, Args),
 
-    Point = #{latitude => 409146138, longitude => -746188906},
-    Ctx = ctx:new(),
-    {ok, Feature, _} = routeguide_route_guide_client:get_feature(Ctx, Point, #{encoding => gzip}),
     ?assertEqual(#{location =>
                        #{latitude => 409146138, longitude => -746188906},
                    name =>
                        <<"Berkshire Valley Management Area Trail, Jefferson, NJ, USA">>}, Feature),
 
-    ?assertMatch(#{data := 300}, oc_stat_view:export(SrvLatencyView)),
+    #{data := #{rows :=  [#{value := #{buckets := Bs,
+                            count := Count,
+                            mean := Mean,
+                            sum := Sum}}]}} = oc_stat_view:export(SrvLatencyView),
+
+    {H, T} = lists:splitwith(fun ({_, C}) -> C =:= 0 end, Bs),
+
+    ?assert(element(1, lists:last(H)) =< MeasuredTime), %% Bucket size > Reported time
+    ?assertEqual(element(2, hd(T)), Count), %% Count = 1 = In bucket
+    ?assert(element(1, lists:last(H)) =< Sum), %% Lower bucket < Reported time
+    ?assert(Sum =< MeasuredTime), %% Reported time < Measured time
+    ?assert(element(1, hd(T)) > Sum), %% Higher bucket > Reported time
+    ?assertEqual(Mean*Count, Sum),
 
     ok.
 


### PR DESCRIPTION
Something with regards to opencensus and grpcbox stats handler seems to be wrong. the latency metrics always report back infinity. Not sure how opencensus is supposed to work with regards to view time units and metric time units, but the conversion seems wrong. I've enlarged the bucket sizes and forced microsecond measurements.