### PR TITLE
allow user provided metadata to override defaults

### DIFF
--- a/src/grpcbox_client_stream.erl
+++ b/src/grpcbox_client_stream.erl
@@ -35,8 +35,8 @@ new_stream(Ctx, Channel, Path, Def=#grpcbox_def{service=Service,
                      encoding := DefaultEncoding,
                      stats_handler := StatsHandler}} ->
             Encoding = maps:get(encoding, Options, DefaultEncoding),
-            RequestHeaders = ?headers(Scheme, Authority, Path, encoding_to_binary(Encoding),
-                                      MessageType, metadata_headers(Ctx)),
+            RequestHeaders = merge_headers(?headers(Scheme, Authority, Path, encoding_to_binary(Encoding),
+                                                    MessageType, metadata_headers(Ctx))),
             case h2_connection:new_stream(Conn, ?MODULE, [#{service => Service,
                                                             marshal_fun => MarshalFun,
                                                             unmarshal_fun => UnMarshalFun,
@@ -72,8 +72,8 @@ send_request(Ctx, Channel, Path, Input, #grpcbox_def{service=Service,
                      stats_handler := StatsHandler}} ->
             Encoding = maps:get(encoding, Options, DefaultEncoding),
             Body = grpcbox_frame:encode(Encoding, MarshalFun(Input)),
-            Headers = ?headers(Scheme, Authority, Path, encoding_to_binary(Encoding),
-                               MessageType, metadata_headers(Ctx)),
+            Headers = merge_headers(?headers(Scheme, Authority, Path, encoding_to_binary(Encoding),
+                                             MessageType, metadata_headers(Ctx))),
 
             %% headers are sent in the same request as creating a new stream to ensure
             %% concurrent calls can't end up interleaving the sending of headers in such

--- a/src/grpcbox_client_stream.erl
+++ b/src/grpcbox_client_stream.erl
@@ -245,9 +245,7 @@ merge_header_field({K, V}, HeadersAcc) ->
 join_header_values({Name, Val}, HeadersAcc) ->
     OrigVal = proplists:get_value(Name, HeadersAcc),
     NewValue = <<OrigVal/binary, <<", ">>/binary, Val/binary>>,
-    io:fwrite("~1p~n", [NewValue]),
     NewList = lists:keyreplace(Name, 1, HeadersAcc, {Name, NewValue}),
-    io:fwrite("new list: ~1p~n", [NewList]),
     NewList.
 
 is_protected_header(Name) ->

--- a/src/grpcbox_client_stream.erl
+++ b/src/grpcbox_client_stream.erl
@@ -15,9 +15,9 @@
 
 -define(protected_headers, [<<"content-type">>, <<"te">>]).
 -define(pseudoheaders(Path, Scheme, Authority), [{<<":method">>, <<"POST">>},
-                          {<<":path">>, Path},
-                          {<<":scheme">>, Scheme},
-                          {<<":authority">>, Authority}]).
+                                                 {<<":path">>, Path},
+                                                 {<<":scheme">>, Scheme},
+                                                 {<<":authority">>, Authority}]).
 -define(headers(Encoding, MessageType, MD), MD ++ [{<<"grpc-encoding">>, Encoding},
                                                    {<<"grpc-message-type">>, MessageType},
                                                    {<<"content-type">>, <<"application/grpc+proto">>},


### PR DESCRIPTION
Addresses #60 

I have used this to override the default `content-type: application/grpc+proto` to successfully publish messages to Google Cloud PubSub.

I realize that this performs a map -> proplist -> map -> proplist conversion, but I didn't want to modify `metadata_headers/1`. If you want to change this approach I'm willing to do so and thanks for this project!

