### PR TITLE
Allow user provided metadata to override default metadata

### DIFF
--- a/src/grpcbox_client_stream.erl
+++ b/src/grpcbox_client_stream.erl
@@ -13,6 +13,7 @@
 
 -include("grpcbox.hrl").
 
+-define(protected_headers, [<<":method">>, <<":path">>, <<":scheme">>, <<":authority">>, <<"content-type">>, <<"te">>]).
 -define(headers(Scheme, Host, Path, Encoding, MessageType, MD), MD ++
                                                                  [{<<":method">>, <<"POST">>},
                                                                  {<<":path">>, Path},
@@ -34,8 +35,8 @@ new_stream(Ctx, Channel, Path, Def=#grpcbox_def{service=Service,
                      encoding := DefaultEncoding,
                      stats_handler := StatsHandler}} ->
             Encoding = maps:get(encoding, Options, DefaultEncoding),
-            RequestHeaders = ?headers(Scheme, Authority, Path, encoding_to_binary(Encoding),
-                                      MessageType, metadata_headers(Ctx)),
+            RequestHeaders = merge_headers(?headers(Scheme, Authority, Path, encoding_to_binary(Encoding),
+                                                    MessageType, metadata_headers(Ctx))),
             case h2_connection:new_stream(Conn, ?MODULE, [#{service => Service,
                                                             marshal_fun => MarshalFun,
                                                             unmarshal_fun => UnMarshalFun,
@@ -71,8 +72,8 @@ send_request(Ctx, Channel, Path, Input, #grpcbox_def{service=Service,
                      stats_handler := StatsHandler}} ->
             Encoding = maps:get(encoding, Options, DefaultEncoding),
             Body = grpcbox_frame:encode(Encoding, MarshalFun(Input)),
-            Headers = ?headers(Scheme, Authority, Path, encoding_to_binary(Encoding),
-                               MessageType, metadata_headers(Ctx)),
+            Headers = merge_headers(?headers(Scheme, Authority, Path, encoding_to_binary(Encoding),
+                                             MessageType, metadata_headers(Ctx))),
 
             %% headers are sent in the same request as creating a new stream to ensure
             %% concurrent calls can't end up interleaving the sending of headers in such
@@ -225,28 +226,52 @@ encoding_to_binary(deflate) -> <<"deflate">>;
 encoding_to_binary(snappy) -> <<"snappy">>;
 encoding_to_binary(Custom) -> atom_to_binary(Custom, latin1).
 
+merge_headers(Headers) ->
+    lists:foldl(fun merge_header_field/2, [], Headers).
+
+merge_header_field({K, V}, HeadersAcc) ->
+    case {is_protected_header(K), proplists:is_defined(K, HeadersAcc)} of
+        {true, true} ->
+            % is protected and already exists, skip
+            HeadersAcc;
+        {false, true} ->
+            % isn't protected and already exists, join
+            join_header_values({K, V}, HeadersAcc);
+        {_, false} ->
+            % doesn't exist, add
+            [{K, V} | HeadersAcc]
+    end.
+
+join_header_values({Name, Val}, HeadersAcc) ->
+    OrigVal = proplists:get_value(Name, HeadersAcc),
+    NewValue = <<OrigVal/binary, <<", ">>/binary, Val/binary>>,
+    NewList = lists:keyreplace(Name, 1, HeadersAcc, {Name, NewValue}),
+    NewList.
+
+is_protected_header(Name) ->
+    lists:member(Name, ?protected_headers).
+
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
-headers_test() ->
+merge_headers_test() ->
     {Scheme, Host, Path, Encoding, MsgType} = {<<"http">>, <<"localhost:9898">>, <<"/grpc.Test/Test">>, <<"identity">>, <<"grpc.TestRequest">>},
     Ctx = ctx:new(),
-    Ctx1 = grpcbox_metadata:append_to_outgoing_ctx(Ctx, #{<<"x-custom-header">> => <<"the-first-shall-be-first">>,
-                                                          <<"content-type">> => <<"application/grpc">>}),
-    Headers = ?headers(Scheme, Host, Path, Encoding, MsgType, metadata_headers(Ctx1)),
+    Ctx1 = grpcbox_metadata:append_to_outgoing_ctx(Ctx, #{<<"content-type">> => <<"application/grpc">>,
+                                                          <<"user-agent">> => <<"custom-grpc-client">>}),
+    Headers0 = ?headers(Scheme, Host, Path, Encoding, MsgType, metadata_headers(Ctx1)),
+    Headers = merge_headers(Headers0),
 
     ?assertEqual([{<<"content-type">>, <<"application/grpc">>},
-                  {<<"x-custom-header">>, <<"the-first-shall-be-first">>},
+                  {<<"user-agent">>, <<"custom-grpc-client, grpc-erlang/0.9.2">>},
                   {<<":method">>, <<"POST">>},
                   {<<":path">>, <<"/grpc.Test/Test">>},
                   {<<":scheme">>, <<"http">>},
                   {<<":authority">>, <<"localhost:9898">>},
                   {<<"grpc-encoding">>, <<"identity">>},
                   {<<"grpc-message-type">>, <<"grpc.TestRequest">>},
-                  {<<"content-type">>, <<"application/grpc+proto">>},
-                  {<<"user-agent">>, <<"grpc-erlang/0.9.2">>},
                   {<<"te">>, <<"trailers">>}
-                 ], Headers),
+                 ], lists:reverse(Headers)),
     ok.
 
 -endif.

--- a/src/grpcbox_client_stream.erl
+++ b/src/grpcbox_client_stream.erl
@@ -13,17 +13,16 @@
 
 -include("grpcbox.hrl").
 
--define(protected_headers, [<<":method">>, <<":path">>, <<":scheme">>, <<":authority">>, <<"content-type">>, <<"te">>]).
--define(headers(Scheme, Host, Path, Encoding, MessageType, MD), MD ++
-                                                                 [{<<":method">>, <<"POST">>},
-                                                                 {<<":path">>, Path},
-                                                                 {<<":scheme">>, Scheme},
-                                                                 {<<":authority">>, Host},
-                                                                 {<<"grpc-encoding">>, Encoding},
-                                                                 {<<"grpc-message-type">>, MessageType},
-                                                                 {<<"content-type">>, <<"application/grpc+proto">>},
-                                                                 {<<"user-agent">>, <<"grpc-erlang/0.9.2">>},
-                                                                 {<<"te">>, <<"trailers">>}]).
+-define(protected_headers, [<<"content-type">>, <<"te">>]).
+-define(pseudoheaders(Path, Scheme, Authority), [{<<":method">>, <<"POST">>},
+                                                 {<<":path">>, Path},
+                                                 {<<":scheme">>, Scheme},
+                                                 {<<":authority">>, Authority}]).
+-define(headers(Encoding, MessageType, MD), MD ++ [{<<"grpc-encoding">>, Encoding},
+                                                   {<<"grpc-message-type">>, MessageType},
+                                                   {<<"content-type">>, <<"application/grpc+proto">>},
+                                                   {<<"user-agent">>, <<"grpc-erlang/0.9.2">>},
+                                                   {<<"te">>, <<"trailers">>}]).
 
 new_stream(Ctx, Channel, Path, Def=#grpcbox_def{service=Service,
                                                 message_type=MessageType,
@@ -35,8 +34,9 @@ new_stream(Ctx, Channel, Path, Def=#grpcbox_def{service=Service,
                      encoding := DefaultEncoding,
                      stats_handler := StatsHandler}} ->
             Encoding = maps:get(encoding, Options, DefaultEncoding),
-            RequestHeaders = merge_headers(?headers(Scheme, Authority, Path, encoding_to_binary(Encoding),
-                                                    MessageType, metadata_headers(Ctx))),
+            UserHeaders = merge_headers(?headers(encoding_to_binary(Encoding), MessageType, metadata_headers(Ctx))),
+            RequestHeaders = ?pseudoheaders(Path, Scheme, Authority) ++ UserHeaders,
+
             case h2_connection:new_stream(Conn, ?MODULE, [#{service => Service,
                                                             marshal_fun => MarshalFun,
                                                             unmarshal_fun => UnMarshalFun,
@@ -72,8 +72,8 @@ send_request(Ctx, Channel, Path, Input, #grpcbox_def{service=Service,
                      stats_handler := StatsHandler}} ->
             Encoding = maps:get(encoding, Options, DefaultEncoding),
             Body = grpcbox_frame:encode(Encoding, MarshalFun(Input)),
-            Headers = merge_headers(?headers(Scheme, Authority, Path, encoding_to_binary(Encoding),
-                                             MessageType, metadata_headers(Ctx))),
+            UserHeaders = merge_headers(?headers(encoding_to_binary(Encoding), MessageType, metadata_headers(Ctx))),
+            RequestHeaders = ?pseudoheaders(Path, Scheme, Authority) ++ UserHeaders,
 
             %% headers are sent in the same request as creating a new stream to ensure
             %% concurrent calls can't end up interleaving the sending of headers in such
@@ -86,7 +86,7 @@ send_request(Ctx, Channel, Path, Input, #grpcbox_def{service=Service,
                                                                           buffer => <<>>,
                                                                           stats_handler => StatsHandler,
                                                                           stats => #{},
-                                                                          client_pid => self()}], Headers, [], self()) of
+                                                                          client_pid => self()}], RequestHeaders, [], self()) of
                 {error, _Code} = Err ->
                     Err;
                 {StreamId, Pid} ->
@@ -255,23 +255,33 @@ is_protected_header(Name) ->
 -include_lib("eunit/include/eunit.hrl").
 
 merge_headers_test() ->
-    {Scheme, Host, Path, Encoding, MsgType} = {<<"http">>, <<"localhost:9898">>, <<"/grpc.Test/Test">>, <<"identity">>, <<"grpc.TestRequest">>},
+    {Encoding, MsgType} = {<<"identity">>, <<"grpc.TestRequest">>},
     Ctx = ctx:new(),
     Ctx1 = grpcbox_metadata:append_to_outgoing_ctx(Ctx, #{<<"content-type">> => <<"application/grpc">>,
                                                           <<"user-agent">> => <<"custom-grpc-client">>}),
-    Headers0 = ?headers(Scheme, Host, Path, Encoding, MsgType, metadata_headers(Ctx1)),
-    Headers = merge_headers(Headers0),
+    Headers0 = ?headers(Encoding, MsgType, metadata_headers(Ctx1)),
+    Headers1 = merge_headers(Headers0),
 
-    ?assertEqual([{<<"content-type">>, <<"application/grpc">>},
-                  {<<"user-agent">>, <<"custom-grpc-client, grpc-erlang/0.9.2">>},
-                  {<<":method">>, <<"POST">>},
-                  {<<":path">>, <<"/grpc.Test/Test">>},
-                  {<<":scheme">>, <<"http">>},
-                  {<<":authority">>, <<"localhost:9898">>},
-                  {<<"grpc-encoding">>, <<"identity">>},
+    ?assertEqual([{<<"te">>, <<"trailers">>},
                   {<<"grpc-message-type">>, <<"grpc.TestRequest">>},
-                  {<<"te">>, <<"trailers">>}
-                 ], lists:reverse(Headers)),
+                  {<<"grpc-encoding">>, <<"identity">>},
+                  {<<"user-agent">>, <<"custom-grpc-client, grpc-erlang/0.9.2">>},
+                  {<<"content-type">>, <<"application/grpc">>}
+                 ], Headers1),
+    ok.
+
+merge_headers_empty_ctx_test() ->
+    {Encoding, MsgType} = {<<"identity">>, <<"grpc.TestRequest">>},
+    Ctx = ctx:new(),
+    Headers0 = ?headers(Encoding, MsgType, metadata_headers(Ctx)),
+    Headers1 = merge_headers(Headers0),
+
+    ?assertEqual([{<<"te">>, <<"trailers">>},
+                  {<<"user-agent">>, <<"grpc-erlang/0.9.2">>},
+                  {<<"content-type">>, <<"application/grpc+proto">>},
+                  {<<"grpc-message-type">>, <<"grpc.TestRequest">>},
+                  {<<"grpc-encoding">>, <<"identity">>}
+                 ], Headers1),
     ok.
 
 -endif.


### PR DESCRIPTION
This PR introduces code that will join duplicate headers into a comma-separated list, if allowed. Otherwise, it will prefer the user supplied value in the case that a default value was provided. It also moves required [pseudo-headers](https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.3) into a separate macro which can't be overridden.

[Section 4.2](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2) of RFC2616 lays out some rules around multiple message headers.
>Multiple message-header fields with the same field-name MAY be present in a message if and only if the entire field-value for that header field is defined as a comma-separated list [i.e., #(values)]. It MUST be possible to combine the multiple header fields into one "field-name: field-value" pair, without changing the semantics of the message, by appending each subsequent field-value to the first, each separated by a comma. The order in which header fields with the same field-name are received is therefore significant to the interpretation of the combined field value, and thus a proxy MUST NOT change the order of these field values when a message is forwarded.

Allowing duplicate headers like `Content-Type` would change the semantic meaning of the request so, in this PR, only the first header processed is kept. This allows user supplied metadata/headers to override the defaults, but prevents duplicates from being sent.

Addresses issue #60.

I've tested this code in my company's backend system and can successfully publish messages to Google Cloud PubSub.