### PR TITLE
Fix stream creation concurrency in new_stream

### DIFF
--- a/src/grpcbox_client_stream.erl
+++ b/src/grpcbox_client_stream.erl
@@ -42,11 +42,10 @@ new_stream(Ctx, Channel, Path, Def=#grpcbox_def{service=Service,
                                                             buffer => <<>>,
                                                             stats_handler => StatsHandler,
                                                             stats => #{},
-                                                            client_pid => self()}], self()) of
+                                                            client_pid => self()}], RequestHeaders, [], self()) of
                 {error, _Code} = Err ->
                     Err;
                 {StreamId, Pid} ->
-                    h2_connection:send_headers(Conn, StreamId, RequestHeaders),
                     Ref = erlang:monitor(process, Pid),
                     {ok, #{channel => Conn,
                            stream_id => StreamId,


### PR DESCRIPTION
The stream concurrency fix for joedevivo/chatterbox#136 had only been taken into use in
grpcbox_client_stream:send_request. This commit adds the fix also
to grpcbox_client_stream:new_stream.