### PR TITLE
Fix interop tests

### DIFF
--- a/interop/src/grpc_testing_test_service.erl
+++ b/interop/src/grpc_testing_test_service.erl
@@ -29,17 +29,16 @@ unary_call(Ctx, Request=#{response_size := Size}) ->
             EchoValue = maps:get(?INITIAL_METADATA_KEY, Metadata, <<>>),
             EchoTrailer = maps:get(?TRAILING_METADATA_KEY, Metadata, <<>>),
             Header = grpcbox_metadata:pairs([{?INITIAL_METADATA_KEY, EchoValue}]),
-            grpcbox_stream:send_headers(Ctx, Header),
+            Ctx1 = ctx:set(Ctx, ctx_stream_key, grpcbox_stream:send_headers(Ctx, Header)),
             Trailer = grpcbox_metadata:pairs([{?TRAILING_METADATA_KEY, EchoTrailer}]),
-            Ctx1 = grpcbox_stream:set_trailers(Ctx, Trailer),
-
+            Ctx2 = grpcbox_stream:set_trailers(Ctx1, Trailer),
             Body = << <<0>> || _ <- lists:seq(1, Size) >>,
             {ok, #{payload => #{type => 'COMPRESSABLE',
                                 body => Body
                                },
                    username => <<"tsloughter">>,
                    oauth_scope => <<"some-scope">>
-                  }, Ctx1}
+                  }, Ctx2}
     end.
 
 -spec cacheable_unary_call(ctx:ctx(), test_pb:simple_request()) ->


### PR DESCRIPTION
Fixes the interop tests so that they pass again. Tested against
both the go client and the grpcbox client. The issue was the calling
send_headers() lost the info that headers have been sent and so later
grpcbox ended up sending headers a second time. Storing the result
of send_headers() into the ctx prevents grpcbox from re-sending
the headers later.

This seems a bit hackish, not sure what the intended way of doing
this without tampering with the ctx is. Couldn't get it to work
using grpcbox_stream:add_headers() either.