### PR TITLE
implement h2_stream:terminate callback

### DIFF
--- a/src/grpcbox_stream.erl
+++ b/src/grpcbox_stream.erl
@@ -24,7 +24,8 @@
          on_receive_headers/2,
          on_send_push_promise/2,
          on_receive_data/2,
-         on_end_stream/1]).
+         on_end_stream/1,
+         terminate/1]).
 
 -export_type([t/0,
               grpc_status/0,
@@ -309,6 +310,9 @@ on_end_stream_(State=#state{method=#method{output={_Output, false}}}) ->
     end_stream(State);
 on_end_stream_(State) ->
     end_stream(State).
+
+terminate(State) ->
+    on_end_stream(State).
 
 %% Internal
 


### PR DESCRIPTION
The terminate callback makes it possible to notice when the
stream was taken down unexpectedly without receiving end_stream,
e.g. due to socket errors etc

In this case on_end_stream() is called also for termination. It will
result in a second eos being sent in case END_STREAM also was
received.

Fixes #72, needs tsloughter/chatterbox#13