### PR TITLE
Support the fd socket option when listening

### DIFF
--- a/test/grpcbox_SUITE.erl
+++ b/test/grpcbox_SUITE.erl
@@ -13,6 +13,7 @@ groups() ->
     [{ssl, [], [unary_authenticated]},
      {tcp, [], [unary_no_auth, multiple_servers,
                 unary_garbage_collect_streams]},
+     {socket_options, [], [fd_socket_option]},
      {concurrent, [{repeat_until_any_fail, 5}], [unary_concurrent]},
      {negative_tests, [], [unimplemented, closed_stream, generate_error, streaming_generate_error]},
      {negative_ssl, [], [unauthorized]},
@@ -22,6 +23,7 @@ groups() ->
 all() ->
     [{group, ssl},
      {group, tcp},
+     {group, socket_options},
      {group, concurrent},
      {group, negative_tests},
      {group, negative_ssl},
@@ -74,6 +76,14 @@ init_per_group(tcp, Config) ->
                                                                               routeguide_route_guide}},
                                              transport_opts => #{}}]),
     application:ensure_all_started(grpcbox),
+    Config;
+init_per_group(socket_options, Config) ->
+    application:set_env(grpcbox, client, #{channels => [{default_channel, [{http, "localhost", 8080, []}],
+                                                         #{}}]}),
+    application:set_env(grpcbox, servers, [#{grpc_opts => #{service_protos => [route_guide_pb],
+                                                            services => #{'routeguide.RouteGuide' =>
+                                                                              routeguide_route_guide}},
+                                             transport_opts => #{}}]),
     Config;
 init_per_group(concurrent, Config) ->
     application:set_env(grpcbox, client, #{channels => [{default_channel, [{http, "localhost", 8080, []}],
@@ -311,6 +321,8 @@ end_per_testcase(unary_no_auth, _Config) ->
 end_per_testcase(multiple_servers, _Config) ->
     ok;
 end_per_testcase(unary_garbage_collect_streams, _Config) ->
+    ok;
+end_per_testcase(fd_socket_option, _Config) ->
     ok;
 end_per_testcase(unary_concurrent, _Config) ->
     ok;
@@ -562,6 +574,24 @@ multiple_servers(_Config) ->
                                                  listen_opts => #{port => 8081}})),
     unary(_Config),
     unary(_Config).
+
+fd_socket_option(_Config) ->
+    %% Use the fd option to dynamically select a free port
+    {ok, Ip} = inet:getaddr("localhost", inet),
+    {ok, Sock} = gen_tcp:listen(0, [{ip, Ip}, inet]),
+    {ok, Fd} = inet:getfd(Sock),
+    {ok, {_ListenIp, ListenPort}} = inet:sockname(Sock),
+    application:set_env(grpcbox, client, #{channels => [{default_channel,
+                                                         [{http, "localhost", ListenPort, []}], #{}}]}),
+
+    application:set_env(grpcbox, servers, [#{grpc_opts => #{service_protos => [route_guide_pb],
+                                                            services => #{'routeguide.RouteGuide' =>
+                                                                              routeguide_route_guide}},
+                                             listen_opts => #{socket_options => [{fd, Fd}]}}]),
+    {ok, _} = application:ensure_all_started(grpcbox),
+    unary(_Config),
+    application:stop(grpcbox),
+    gen_tcp:close(Sock).
 
 unary_concurrent(Config) ->
     Nrs = lists:seq(1,100),


### PR DESCRIPTION
This PR allows the user to set the `{fd,Fd}` socket option when starting a grpc server. One use for this is if we want to open on any free port number, but may want to control the ip address. Another use case could be if the fd was opened by an external program with more privileges and sent to erlang using `sendmsg(2)`, for instance with [fd_server](https://github.com/gebi/jungerl/tree/master/lib/fd_server).

I'll try to describe our context a bit which led us to this proposal. We start grpc servers dynamically and, depending on our user, we may need to start several grpc servers. We may have to stick to some particular ip address, and we are not alone on the server, so we can often not bind to all addresses. But we can use any available port number. So we would ideally like to set the port to 0 to let the operating system assign us some available port. We have some means to communicate the dynamically selected port number to the user.

First we tried to set the `ip` option and the `port => 0` option, but we faced a couple of other issues: one is that the port number is used as part of a process name and we would like to be able to open more than one grpc server for a particular ip address, another issue was that we would need to somehow get hold of the socket to learn what port number was actually assigned by the operating system.

The fd option could solves both of these issues: we can open the listen socket in advance, use inet:sockname/1 and set the `ip` and `port` options. Just gen_tcp need to be convinced to not try to bind, and this is what this PR does.

Do you think this could be ok?