### PR TITLE
update state correctly in grpcbox_stream:on_end_stream()

### DIFF
--- a/src/grpcbox_stream.erl
+++ b/src/grpcbox_stream.erl
@@ -293,24 +293,25 @@ handle_unary(Ctx, Message, State=#state{unary_interceptor=UnaryInterceptor,
     end.
 
 on_end_stream(State) ->
-    on_end_stream_(State),
-    {ok, State}.
+    on_end_stream_(State).
 
-on_end_stream_(#state{input_ref=Ref,
-                      callback_pid=Pid,
-                      method=#method{input={_Input, true},
-                                     output={_Output, false}}}) ->
-    Pid ! {Ref, eos};
-on_end_stream_(#state{input_ref=Ref,
-                      callback_pid=Pid,
-                      method=#method{input={_Input, true},
-                                     output={_Output, true}}}) ->
-    Pid ! {Ref, eos};
-on_end_stream_(#state{input_ref=_Ref,
-                      callback_pid=_Pid,
-                      method=#method{input={_Input, false},
-                                     output={_Output, true}}}) ->
-    ok;
+on_end_stream_(State=#state{input_ref=Ref,
+                            callback_pid=Pid,
+                            method=#method{input={_Input, true},
+                                           output={_Output, false}}}) ->
+    Pid ! {Ref, eos},
+    {ok, State};
+on_end_stream_(State=#state{input_ref=Ref,
+                            callback_pid=Pid,
+                            method=#method{input={_Input, true},
+                                           output={_Output, true}}}) ->
+    Pid ! {Ref, eos},
+    {ok, State};
+on_end_stream_(State=#state{input_ref=_Ref,
+                            callback_pid=_Pid,
+                            method=#method{input={_Input, false},
+                                           output={_Output, true}}}) ->
+    {ok, State};
 on_end_stream_(State=#state{method=#method{output={_Output, false}}}) ->
     end_stream(State);
 on_end_stream_(State) ->


### PR DESCRIPTION
Previously the original state was returned, even though the state could be updated in end_stream(). Following the addition of h2_stream:terminate() this leads to the stats_handler being called twice, making the server_latency_stats testcase fail. With the fix, stats_handler rpc_end will be called once as expected and the test will pass.