### PR TITLE
Set grpc-timeout in milliseconds

### DIFF
--- a/src/grpcbox_client_stream.erl
+++ b/src/grpcbox_client_stream.erl
@@ -129,7 +129,8 @@ metadata_headers(Ctx) ->
         D when D =:= undefined ; D =:= infinity ->
             grpcbox_utils:encode_headers(maps:to_list(grpcbox_metadata:from_outgoing_ctx(Ctx)));
         {T, _} ->
-            Timeout = {<<"grpc-timeout">>, <<(integer_to_binary(T - erlang:monotonic_time()))/binary, "n">>},
+            TimeMs = erlang:convert_time_unit(T - erlang:monotonic_time(), native, millisecond),
+            Timeout = {<<"grpc-timeout">>, <<(integer_to_binary(TimeMs))/binary, "m">>},
             grpcbox_utils:encode_headers([Timeout | maps:to_list(grpcbox_metadata:from_outgoing_ctx(Ctx))])
     end.
 


### PR DESCRIPTION
Setting it in nanoseconds overflowed the maximum length (8) of the header already at 100ms, causing PROTOCOL_ERROR responses. Using ms instead of ns is not bullet proof either, but covers the range of 1ms - ~27h. Seems most if not all use cases should fit in this range and doing extra calculations for covering more range might not be worth it performance-wise.

Fixes #85 