### PR TITLE
Unary request timeout modifications

### DIFF
--- a/src/grpcbox_client.erl
+++ b/src/grpcbox_client.erl
@@ -78,7 +78,7 @@ unary_handler(Ctx, Channel, Path, Input, Def, Options) ->
                       stream_pid => Pid,
                       monitor_ref => Ref,
                       service_def => Def},
-                case recv_end(S, 5000) of
+                case recv_end(S, grpcbox_utils:get_timeout_from_ctx(Ctx, 5000)) of
                     eos ->
                         case recv_headers(S, 0) of
                             {ok, Headers} ->

--- a/src/grpcbox_client_stream.erl
+++ b/src/grpcbox_client_stream.erl
@@ -27,7 +27,7 @@ new_stream(Ctx, Channel, Path, Def=#grpcbox_def{service=Service,
                                                 message_type=MessageType,
                                                 marshal_fun=MarshalFun,
                                                 unmarshal_fun=UnMarshalFun}, Options) ->
-    case grpcbox_subchannel:conn(Channel) of
+    case grpcbox_subchannel:conn(Channel, grpcbox_utils:get_timeout_from_ctx(Ctx, infinity)) of
         {ok, Conn, #{scheme := Scheme,
                      authority := Authority,
                      encoding := DefaultEncoding,
@@ -62,7 +62,7 @@ send_request(Ctx, Channel, Path, Input, #grpcbox_def{service=Service,
                                                      message_type=MessageType,
                                                      marshal_fun=MarshalFun,
                                                      unmarshal_fun=UnMarshalFun}, Options) ->
-    case grpcbox_subchannel:conn(Channel) of
+    case grpcbox_subchannel:conn(Channel, grpcbox_utils:get_timeout_from_ctx(Ctx, infinity)) of
         {ok, Conn, #{scheme := Scheme,
                      authority := Authority,
                      encoding := DefaultEncoding,

--- a/src/grpcbox_subchannel.erl
+++ b/src/grpcbox_subchannel.erl
@@ -3,7 +3,8 @@
 -behaviour(gen_statem).
 
 -export([start_link/5,
-         conn/1]).
+         conn/1,
+         conn/2]).
 -export([init/1,
          callback_mode/0,
          terminate/3,
@@ -26,7 +27,13 @@ start_link(Name, Channel, Endpoint, Encoding, StatsHandler) ->
     gen_statem:start_link(?MODULE, [Name, Channel, Endpoint, Encoding, StatsHandler], []).
 
 conn(Pid) ->
-    gen_statem:call(Pid, conn).
+    conn(Pid, infinity).
+conn(Pid, Timeout) ->
+    try
+        gen_statem:call(Pid, conn, Timeout)
+    catch
+        exit:{timeout, _} -> {error, timeout}
+    end.
 
 init([Name, Channel, Endpoint, Encoding, StatsHandler]) ->
     process_flag(trap_exit, true),

--- a/src/grpcbox_utils.erl
+++ b/src/grpcbox_utils.erl
@@ -99,12 +99,12 @@ status_to_string(Code) ->
     <<"CODE_", Code/binary>>.
 
 get_timeout_from_ctx(Ctx, DefaultTimeout) ->
-    Ret = case ctx:deadline(Ctx) of
-              undefined ->
-                  DefaultTimeout;
-              infinity ->
-                  infinity;
-              {Deadline, _} ->
-                  erlang:convert_time_unit(Deadline - erlang:monotonic_time(), native, millisecond)
-          end,
-    Ret.
+    case ctx:deadline(Ctx) of
+        undefined ->
+            DefaultTimeout;
+        infinity ->
+            infinity;
+        {Deadline, _} ->
+           erlang:convert_time_unit(Deadline - erlang:monotonic_time(), native, millisecond)
+    end.
+

--- a/src/grpcbox_utils.erl
+++ b/src/grpcbox_utils.erl
@@ -5,7 +5,8 @@
          decode_header/1,
          encode_headers/1,
          is_reserved_header/1,
-         status_to_string/1]).
+         status_to_string/1,
+         get_timeout_from_ctx/2]).
 
 -include("grpcbox.hrl").
 
@@ -96,3 +97,14 @@ status_to_string(?GRPC_STATUS_UNAUTHENTICATED) ->
     <<"UNAUTHENTICATED">>;
 status_to_string(Code) ->
     <<"CODE_", Code/binary>>.
+
+get_timeout_from_ctx(Ctx, DefaultTimeout) ->
+    Ret = case ctx:deadline(Ctx) of
+              undefined ->
+                  DefaultTimeout;
+              infinity ->
+                  infinity;
+              {Deadline, _} ->
+                  erlang:convert_time_unit(Deadline - erlang:monotonic_time(), native, millisecond)
+          end,
+    Ret.


### PR DESCRIPTION
Applies the deadline timeout to two cases:
- The timeout of an ongoing unary request (instead of hardcoded 5s)
- The timeout of requests waiting for the GRPC channel to connect (currently min 5s, max infinity because of #80)

Fixes #80, #90.

Note: Here the deadline calculation from the ctx has been put in grpcbox_utils. It might be better to put it in the ctx itself as was done in tsloughter/ctx#4.