### PR TITLE
Stabilize garbage collection tests

### DIFF
--- a/test/grpcbox_SUITE.erl
+++ b/test/grpcbox_SUITE.erl
@@ -549,6 +549,7 @@ unary_garbage_collect_streams(Config) ->
 client_stream_garbage_collect_streams(Config) ->
     client_stream(Config),
 
+    timer:sleep(100),
     ConnectionStreamSet = connection_stream_set(),
 
     ?assertEqual([], h2_stream_set:my_active_streams(ConnectionStreamSet)).


### PR DESCRIPTION
The client_stream_garbage_collect_streams test occasionally fails because sometimes the check for collected streams is run before the streams have been finished. To stabilize the test, allow some retries to ensure the stream has enough time to be collected.