### PR TITLE
Include paths are agnostic about root dir name

### DIFF
--- a/interop/src/grpc_testing_reconnect_service_client.erl
+++ b/interop/src/grpc_testing_reconnect_service_client.erl
@@ -10,7 +10,7 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
--include_lib("grpcbox/include/grpcbox.hrl").
+-include_lib("include/grpcbox.hrl").
 
 -define(is_ctx(Ctx), is_tuple(Ctx) andalso element(1, Ctx) =:= ctx).
 

--- a/interop/src/grpc_testing_test_service_client.erl
+++ b/interop/src/grpc_testing_test_service_client.erl
@@ -10,7 +10,7 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
--include_lib("grpcbox/include/grpcbox.hrl").
+-include_lib("include/grpcbox.hrl").
 
 -define(is_ctx(Ctx), is_tuple(Ctx) andalso element(1, Ctx) =:= ctx).
 

--- a/interop/src/grpc_testing_unimplemented_service_client.erl
+++ b/interop/src/grpc_testing_unimplemented_service_client.erl
@@ -10,7 +10,7 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
--include_lib("grpcbox/include/grpcbox.hrl").
+-include_lib("include/grpcbox.hrl").
 
 -define(is_ctx(Ctx), is_tuple(Ctx) andalso element(1, Ctx) =:= ctx).
 

--- a/src/grpcbox_health_client.erl
+++ b/src/grpcbox_health_client.erl
@@ -10,7 +10,7 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
--include_lib("grpcbox/include/grpcbox.hrl").
+-include_lib("include/grpcbox.hrl").
 
 -define(is_ctx(Ctx), is_tuple(Ctx) andalso element(1, Ctx) =:= ctx).
 

--- a/src/grpcbox_reflection_client.erl
+++ b/src/grpcbox_reflection_client.erl
@@ -10,7 +10,7 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
--include_lib("grpcbox/include/grpcbox.hrl").
+-include_lib("include/grpcbox.hrl").
 
 -define(is_ctx(Ctx), is_tuple(Ctx) andalso element(1, Ctx) =:= ctx).
 

--- a/test/routeguide_route_guide_client.erl
+++ b/test/routeguide_route_guide_client.erl
@@ -10,7 +10,7 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
--include_lib("grpcbox/include/grpcbox.hrl").
+-include_lib("include/grpcbox.hrl").
 
 -define(is_ctx(Ctx), is_tuple(Ctx) andalso element(1, Ctx) =:= ctx).
 


### PR DESCRIPTION
Remove `grpcbox/` prefix in include paths. This fixes packaging in nix, which uses a custom directory name to store the source code of hex packages.

See:

https://github.com/ydlr/mix2nix/pull/18#issuecomment-1708998005  
https://github.com/NixOS/nixpkgs/blob/f3bbbcd40712205f37cc1060d8e5dfa3639f2d70/pkgs/development/beam-modules/fetch-hex.nix#L10