### PR TITLE
Fix error handling for streaming RPCs

### DIFF
--- a/src/grpcbox_stream.erl
+++ b/src/grpcbox_stream.erl
@@ -172,20 +172,28 @@ authenticate({ok, Cert}, Fun) ->
 authenticate(_, _) ->
     false.
 
-handle_streams(Ref, State=#state{full_method=FullMethod,
-                                 stream_interceptor=StreamInterceptor,
-                                 method=#method{module=Module,
-                                                function=Function,
-                                                output={_, false}}}) ->
-    case (case StreamInterceptor of
-              undefined -> Module:Function(Ref, State);
-              _ ->
-                  ServerInfo = #{full_method => FullMethod,
-                                 service => Module,
-                                 input_stream => true,
-                                 output_stream => false},
-                  StreamInterceptor(Ref, State, ServerInfo, fun Module:Function/2)
-          end) of
+maybe_call_interceptor(RefOrMsg,
+                       #state{stream_interceptor=StreamInterceptor,
+                              method=#method{module=Module,
+                                             function=Function}} = State)
+  when StreamInterceptor == undefined ->
+    Module:Function(RefOrMsg, State);
+maybe_call_interceptor(RefOrMsg,
+                       #state{stream_interceptor=StreamInterceptor,
+                              full_method=FullMethod,
+                              method=#method{module=Module,
+                                             function=Function,
+                                             output={_, StreamOut},
+                                             input={_, StreamIn}}} = State) ->
+    ServerInfo = #{full_method => FullMethod,
+                   service => Module,
+                   output_stream => StreamOut,
+                   input_stream => StreamIn},
+    Fun = fun Module:Function/2,
+    StreamInterceptor(RefOrMsg, State, ServerInfo, Fun).
+
+handle_streams(Ref, #state{method=#method{output={_, false}}}=State) ->
+    case maybe_call_interceptor(Ref, State) of
         {ok, Response, State2} ->
             send(Response, State2);
         E={grpc_error, _} ->
@@ -193,20 +201,13 @@ handle_streams(Ref, State=#state{full_method=FullMethod,
         E={grpc_extended_error, _} ->
             throw(E)
     end;
-handle_streams(Ref, State=#state{full_method=FullMethod,
-                                 stream_interceptor=StreamInterceptor,
-                                 method=#method{module=Module,
-                                                function=Function,
-                                                output={_, true}}}) ->
-    case StreamInterceptor of
-        undefined ->
-            Module:Function(Ref, State);
-        _ ->
-            ServerInfo = #{full_method => FullMethod,
-                           service => Module,
-                           input_stream => true,
-                           output_stream => true},
-            StreamInterceptor(Ref, State, ServerInfo, fun Module:Function/2)
+handle_streams(RefOrMsg, #state{method=#method{output={_, true}}}=State) ->
+    case maybe_call_interceptor(RefOrMsg, State) of
+        E={grpc_error, _} ->
+            throw(E);
+        E={grpc_extended_error, _} ->
+            throw(E);
+        R -> R
     end.
 
 on_send_push_promise(_, State) ->
@@ -411,6 +412,8 @@ handle_info({send_proto, Message}, State) ->
 handle_info({'EXIT', _, normal}, State) ->
     end_stream(State),
     State;
+handle_info({'EXIT', Pid, {{nocatch, Exception}, _}}, State) ->
+    handle_info({'EXIT', Pid, Exception}, State);
 handle_info({'EXIT', _, {grpc_error, {Status, Message}}}, State) ->
     end_stream(Status, Message, State),
     State;


### PR DESCRIPTION
Fixes an issue where grpcbox ignores errors that are returned from the callback function of a streaming RPC. This happened both on RPCs with streaming and non-streaming output, though the behaviour was different: For non-streaming output, grpcbox always returned a generic error, generated in `grpcbox_stream.erl` line 425 (on this commit).
For streaming output, errors were completely ignored and the stream was closed without an error indication to the client.

Also fixes a small issue where grpcbox passed incorrect ServerInfo to streaming interceptors for RPCs with only streaming output.